### PR TITLE
avoid emitting results on response.ok == False

### DIFF
--- a/crawlers/lib/crawl.py
+++ b/crawlers/lib/crawl.py
@@ -43,7 +43,7 @@ def process_block_url(session, block_url) -> None:
     if block_data.get("status") == "sleep":
         retry_time = block_data["retry_at"]
         sleep_time = retry_time - time.time()
-        print(f"sleeping {sleep_time}...")
+        logger.info(f"sleeping {sleep_time}...")
         time.sleep(sleep_time)
         return
 

--- a/crawlers/lib/platforms/gitea.py
+++ b/crawlers/lib/platforms/gitea.py
@@ -37,6 +37,8 @@ class GiteaCrawler(ICrawler):
             )
             try:
                 response = self.requests.get(self.request_url, params=params)
+                if not response.ok:
+                    return False, [], state
                 result = response.json()
             except Exception as e:
                 logger.error(e)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,9 +10,10 @@ services:
 
     restart: ${RESTART}
 
+    # DISABLED as it was failing seemingly randomly (on mac)
     # uplink port to host
-    ports:
-      - 8080-8999:8080
+    # ports:
+    #   - 8080-8999:8080
 
     #command: >
     #  bash -ic " \
@@ -33,7 +34,7 @@ services:
         "
 
   gitlab_crawler:
-    scale: 0
+    scale: 1
     extends: service
     command: >
       bash -ic " \
@@ -41,6 +42,7 @@ services:
         flask cli crawl-type gitlab
         "
   github_crawler:
+    scale: 1
     extends: service
     command: >
       bash -ic " \


### PR DESCRIPTION
We sent back "error" strings instead of repos because we didnt check if response.ok was true on each API request.