### PR TITLE
crawler uuid

### DIFF
--- a/crawlers/lib/platforms/i_crawler.py
+++ b/crawlers/lib/platforms/i_crawler.py
@@ -32,7 +32,7 @@ class ICrawler:
                         status_forcelist=[429, 500, 502, 503, 504])
         self.requests.mount("https://", HTTPAdapter(max_retries=retries))
         if user_agent is not None:
-            self.requests.headers.update({"user-agent": user_agent})
+            self.requests.headers.update({"User-Agent": user_agent})
 
     def __str__(self):
         return f'<{self.type}@{self.base_url}>'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
         pip install -r requirements.txt
         flask cli crawl-type gitlab
         "
+
   github_crawler:
     scale: 1
     extends: service
@@ -49,6 +50,7 @@ services:
         pip install -r requirements.txt
         flask cli crawl-type github
         "
+
 networks:
   hubgrep:
     name: hubgrep


### PR DESCRIPTION
just a uuid in a header, has no effect on anything in itself (so safe to merge whenever) - but now we can look for that, and puzzle it together with the request ip in the indexer to group ids for our crawler